### PR TITLE
cache getters

### DIFF
--- a/packages/reactivity/src/index.ts
+++ b/packages/reactivity/src/index.ts
@@ -1,11 +1,12 @@
 import { Effect, effect, release, stop } from './Effect';
 import type { ReactiveEffect } from './Effect';
-import { Signal, untrack } from './Signal';
+import { Signal, computed, untrack } from './Signal';
 import { reactive, toRaw } from './reactive';
 
 export {
   Signal,
   untrack,
+  computed,
   Effect,
   ReactiveEffect,
   effect,

--- a/packages/reactivity/src/reactive/index.ts
+++ b/packages/reactivity/src/reactive/index.ts
@@ -1,10 +1,4 @@
 export { collectionTraps } from './collectionMethods';
 export { proxyMap } from './proxyMap';
-export {
-  reactive,
-  makeMapReactive,
-  makeSetReactive,
-  wrap,
-  toRaw,
-} from './reactive';
+export { reactive, wrap, toRaw } from './reactive';
 export { reactiveNodes } from './reactiveNodes';

--- a/packages/reactivity/src/reactive/symbols.ts
+++ b/packages/reactivity/src/reactive/symbols.ts
@@ -2,3 +2,4 @@ export const $EMPTY = Symbol('$EMPTY');
 export const $PROXY = Symbol('$PROXY');
 export const $RAW = Symbol('$RAW');
 export const $SIZE = Symbol('$SIZE');
+export const $CACHEGETTERS = Symbol('$CACHEGETTERS');

--- a/packages/reactivity/src/utils/index.ts
+++ b/packages/reactivity/src/utils/index.ts
@@ -3,4 +3,4 @@ export { isGetter } from './isGetter';
 export { isObject } from './isObject';
 export { isWeakType, isSetType, isMapType } from './isOfClass';
 export { isSetter } from './isSetter';
-export type { WeakTypes, SetTypes, MapTypes } from './isOfClass';
+export type { MapTypes, SetTypes, WeakTypes } from './isOfClass';

--- a/packages/reactivity/vite.config.ts
+++ b/packages/reactivity/vite.config.ts
@@ -20,6 +20,7 @@ export default defineConfig({
     '"$RAW"': '',
     '"$SIZE"': '',
     '"$EMPTY"': '',
+    '"$CACHEGETTERS"': '',
   },
   build: {
     target: 'esnext',

--- a/size.json
+++ b/size.json
@@ -1,22 +1,22 @@
 {
   "reactivity": {
     "minified": {
-      "pretty": "4.53 kB",
-      "raw": 4528
+      "pretty": "4.73 kB",
+      "raw": 4728
     },
     "brotli": {
-      "pretty": "1.55 kB",
-      "raw": 1549
+      "pretty": "1.61 kB",
+      "raw": 1615
     }
   },
   "alpinejs": {
     "minified": {
-      "pretty": "35.7 kB",
-      "raw": 35723
+      "pretty": "36 kB",
+      "raw": 35967
     },
     "brotli": {
-      "pretty": "11.9 kB",
-      "raw": 11914
+      "pretty": "12 kB",
+      "raw": 11998
     }
   }
 }

--- a/size.json
+++ b/size.json
@@ -1,12 +1,12 @@
 {
   "reactivity": {
     "minified": {
-      "pretty": "4.46 kB",
-      "raw": 4459
+      "pretty": "4.53 kB",
+      "raw": 4528
     },
     "brotli": {
-      "pretty": "1.52 kB",
-      "raw": 1520
+      "pretty": "1.55 kB",
+      "raw": 1549
     }
   },
   "alpinejs": {


### PR DESCRIPTION
This PR provides computed signals and allows the caching of getters on reactive objects (which turns them into computed signals)

- :sparkles: Adds computed signals
- :sparkles: Allows caching getters
